### PR TITLE
Set UTF-8 locale to fix issue with UTF-8 file names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,21 @@
 FROM ubuntu:14.04
 MAINTAINER Arthur Caranta <arthur@caranta.com>
 
-RUN apt-get update
+# Set the UTF-8 encoding and locale
+RUN locale-gen en_US.UTF-8  
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8 
+
+# Make sure the package repository is up to date
+RUN apt-get update && apt-get upgrade -y
+
+# Install Python
 RUN apt-get -y install python-pip
 RUN pip install docker-py
+
+# Clean up APT when done.
+RUN apt-get -qy clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ADD backup.py /backup.py
 WORKDIR /


### PR DESCRIPTION
When backing up a data container with windows files, it always stopped with the following exception. Setting the right locale helps tar to use the right file name conversion.

Backing up : /btsync
writing meta data to file 
/data/btsync /var/lib/docker/vfs/dir/7af30504189f3af01e5e414a0d397f6f012a0db584b5b1b40cef54a047bf44a1
Traceback (most recent call last):
  File "/backup.py", line 63, in <module>
    tar.add(volumes[v],v)
  File "/usr/lib/python2.7/tarfile.py", line 2002, in add
    recursive, exclude, filter)
  File "/usr/lib/python2.7/tarfile.py", line 2002, in add
    recursive, exclude, filter)
  File "/usr/lib/python2.7/tarfile.py", line 2002, in add
    recursive, exclude, filter)
  File "/usr/lib/python2.7/tarfile.py", line 2002, in add
    recursive, exclude, filter)
  File "/usr/lib/python2.7/tarfile.py", line 2002, in add
    recursive, exclude, filter)
  File "/usr/lib/python2.7/tarfile.py", line 2001, in add
    self.add(os.path.join(name, f), os.path.join(arcname, f),
  File "/usr/lib/python2.7/posixpath.py", line 80, in join
    path += '/' + b
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 12: ordinal not in range(128)
